### PR TITLE
fix fieldnames to follow json convention. added age and avg age to distinguish the difference between age vs daysToClose

### DIFF
--- a/gdm/mine.py
+++ b/gdm/mine.py
@@ -1,6 +1,7 @@
 import argparse
 from pymongo import MongoClient
 from github import Github
+from datetime import datetime
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-d", "--database", type=str, required=True)
@@ -24,6 +25,8 @@ repos_issues_col = db["repos_issues"]
 # connect to github
 g = Github(args.github_api_key)
 
+today = datetime.today()
+
 # get all the repos under the given org and upsert to the db.repos
 org = g.get_organization(args.organization)
 for repo in org.get_repos():
@@ -45,17 +48,20 @@ for repo in org.get_repos():
     # get all the prs under the repo and upsert to the db.repos_pulls
     for pr in repo.get_pulls(state="all"):
         pr_json = {
-            "repo_id": repo.id,
-            "repo_name": repo.name,
+            "repoId": repo.id,
+            "repoName": repo.name,
             "id": pr.id,
             "title": pr.title,
             "state": pr.state,
-            "created_at": pr.created_at.strftime("%Y-%m-%d"),
+            "createdAt": pr.created_at.strftime("%Y-%m-%d"),
         }
 
-        if pr.closed_at is not None:
-            pr_json["closed_at"] = pr.closed_at.strftime("%Y-%m-%d")
-            pr_json["days_to_close"] = (pr.closed_at - pr.created_at).days
+        if pr.closed_at is None:
+            pr_json["age"] = (today - pr.created_at).days
+        else:
+            pr_json["closedAt"] = pr.closed_at.strftime("%Y-%m-%d")
+            pr_json["daysToClose"] = (pr.closed_at - pr.created_at).days
+            pr_json["age"] = pr_json["daysToClose"]
 
         pr_json_set = {"$set": pr_json}
         print("upserting... ", pr_json)
@@ -69,19 +75,19 @@ for repo in org.get_repos():
     # get all the issues under the repo and upsert to the db.repos_issues
     for issue in repo.get_issues(state="all"):
         issue_json = {
-            "repo_id": repo.id,
-            "repo_name": repo.name,
+            "repoId": repo.id,
+            "repoName": repo.name,
             "id": issue.id,
             "number": issue.number,
             "title": issue.title,
             "body": issue.body,
             "state": issue.state,
-            "created_at": issue.created_at.strftime("%Y-%m-%d"),
+            "createdAt": issue.created_at.strftime("%Y-%m-%d"),
         }
 
         if issue.closed_at is not None:
-            issue_json["closed_at"] = issue.closed_at.strftime("%Y-%m-%d")
-            issue_json["days_to_close"] = (issue.closed_at - issue.created_at).days
+            issue_json["closedAt"] = issue.closed_at.strftime("%Y-%m-%d")
+            issue_json["daysToClose"] = (issue.closed_at - issue.created_at).days
 
         issue_set = {"$set": issue_json}
         print("upserting... ", issue_json)


### PR DESCRIPTION
- repos_pulls.`age` which should be calculated when the PR is open as well using today as the time.
- repos_pulls.`daysToClose` which is only calculated when a PR is closed
- fix the field names as discussed earlier in another pr.

_dashboard breaking changes._

Signed-off-by: Mike Ng <ming@redhat.com>